### PR TITLE
Better api abstraction

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,7 @@
 
 # misc
 .DS_Store
+.VSCodeCounter
 *.pem
 .vscode
 

--- a/src/components/bitcoin-price-manager.tsx
+++ b/src/components/bitcoin-price-manager.tsx
@@ -1,7 +1,7 @@
 import BigNumber from 'bignumber.js';
 import dayjs from 'dayjs';
 import {useInterval} from 'hooks/use-interval';
-import {getBTCPriceNow} from 'lib/util';
+import api from 'lib/api';
 import * as React from 'react';
 import {Component} from 'types/common';
 import {CalculationModes, RefreshModes, useSettings} from './settings-context';
@@ -68,14 +68,17 @@ const BitcoinPriceProvider: Component = ({children}) => {
 export const refreshBTCPrice = (
   setPriceInfo: PriceDispatch
 ): Promise<BigNumber | void> =>
-  getBTCPriceNow().then((price) => {
-    setPriceInfo({amount: price, fetchedAt: dayjs()});
-  });
+  api
+    .getBTCPrice()
+    .then((price) => {
+      setPriceInfo({amount: price, fetchedAt: dayjs()});
+    })
+    .catch((err) => console.error('Failed to refresh btc price from api', err));
 
 const useBitcoinPriceDispatch = (): PriceDispatch => {
   const context = React.useContext(BitcoinPriceContext);
   if (context === null) {
-    throw new Error('used useBitcoinPrice outside provider');
+    throw new Error('used useBitcoinPriceDispatch outside provider');
   }
   return context[1];
 };

--- a/src/components/expense/expense-display.tsx
+++ b/src/components/expense/expense-display.tsx
@@ -9,7 +9,7 @@ import {
 import {PriceBadge} from 'components/price-badge';
 import {CalculationModes, useSettings} from 'components/settings-context';
 import {useBitcoinPrice} from 'components/bitcoin-price-manager';
-import {convertUSDToBTC} from 'lib/util';
+import {convertCurrency} from 'lib/util';
 
 type ExpenseDisplayProps = TExpense & {toggle: () => void};
 
@@ -28,7 +28,7 @@ const ExpenseDisplay = ({
 
   const displayBtcPrice =
     settings.mode === CalculationModes.MARKET
-      ? convertUSDToBTC(usdPrice, oneBitcoin)
+      ? convertCurrency(usdPrice, oneBitcoin)
       : btcPrice;
 
   return (

--- a/src/example.json
+++ b/src/example.json
@@ -1,8 +1,0 @@
-{
-  "bpi": {"2021-08-07": 44606.61},
-  "disclaimer": "This data was produced from the CoinDesk Bitcoin Price Index. BPI value data returned as USD.",
-  "time": {
-    "updated": "Aug 8, 2021 00:32:47 UTC",
-    "updatedISO": "2021-08-08T00:32:47+00:00"
-  }
-}

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -1,0 +1,78 @@
+import BigNumber from 'bignumber.js';
+import dayjs from 'dayjs';
+import {convertCurrency, isToday} from './util';
+
+// In the real world, these can be more robust, perhaps with fallback to another
+// apis and better error handling.
+
+type CoinDeskData = {
+  bpi: Record<string, number>;
+  disclaimer: string;
+  time: Record<string, string>;
+};
+
+// Fetch wrapper for easy replace if needed
+const restClient = async <T extends unknown>(endpoint: string): Promise<T> =>
+  window.fetch(endpoint).then((response) => response.json());
+
+// Gets the btc equivalent of a usd amount from the blockchain.info api
+const convertUSDToBTCAtCurrentPrice = async (
+  usdAmount: BigNumber
+): Promise<BigNumber> => {
+  const endpoint = `https://blockchain.info/tobtc?currency=USD&value=${usdAmount.toString()}`;
+  return restClient<string>(endpoint).then((data) => new BigNumber(data));
+};
+
+// Gets the price of BTC at day close on any given historical date.
+const getHistoricalBTCPrice = async (
+  date: dayjs.Dayjs = dayjs()
+): Promise<BigNumber> => {
+  const formattedDate = date.format('YYYY-MM-DD');
+  const endpoint = `https://api.coindesk.com/v1/bpi/historical/close.json?start=${formattedDate}&end=${formattedDate}`;
+  return restClient<CoinDeskData>(endpoint).then(
+    ({bpi}) => new BigNumber(bpi[formattedDate])
+  );
+};
+
+// Gets the price of bitcoin at a given date.
+// This is used for the price manager cache.
+// Historical dates: Price of bitcoin for a past date comes from coindesk
+// Today's price: Price of bitcoin is calculated from converting 1 million USD to BTC at blockchain.info
+//
+// Note: originally I was using 100MM (to maximize an 8 decimal place precision) but the api seems unstable with large numbers
+const getBTCPrice = async (date: dayjs.Dayjs = dayjs()): Promise<BigNumber> => {
+  let btcPrice: BigNumber;
+  if (isToday(date)) {
+    const oneMillionUSD = new BigNumber(1000000);
+    btcPrice = await convertUSDToBTCAtCurrentPrice(
+      new BigNumber(oneMillionUSD)
+    ).then(
+      (btc) => oneMillionUSD.dividedBy(btc).dp(8) // Cap precision of bitcoin at 8 decimals (satoshis)
+    );
+  } else {
+    btcPrice = await getHistoricalBTCPrice(date);
+  }
+  return btcPrice;
+};
+
+// Converts USD to bitcoin by calling blockchain if date is today, coindesk if historical.
+// This is used mostly for storage values of expenses.
+const convertUSDToBTC = async (
+  date: dayjs.Dayjs = dayjs(),
+  usdPrice: BigNumber
+): Promise<BigNumber> => {
+  try {
+    if (isToday(date)) {
+      return await convertUSDToBTCAtCurrentPrice(usdPrice);
+    } else {
+      return convertCurrency(usdPrice, await getHistoricalBTCPrice(date));
+    }
+  } catch (err) {
+    console.error('Error when converting USD', err);
+    return new BigNumber(0);
+  }
+};
+
+const api = {convertUSDToBTC, getBTCPrice};
+
+export default api;

--- a/src/lib/util.ts
+++ b/src/lib/util.ts
@@ -3,67 +3,11 @@ import {Expense} from 'components/expenses-context';
 import {CalculationModes} from 'components/settings-context';
 import dayjs from 'dayjs';
 
-// In the real world, these would be much more robust, perhaps with fallback to another
-// apis and better error handling.
-
-/**
- * Gets the btc equivalent of a usd amount from the blockchain.info api
- */
-export const getBTCFromUSDAtMarket = async (
-  usdAmount: BigNumber
-): Promise<BigNumber> => {
-  const endpoint = `https://blockchain.info/tobtc?currency=USD&value=${usdAmount.toString()}`;
-  return fetch(endpoint)
-    .then((data) => data.json())
-    .then((res) => new BigNumber(res));
-};
-
-/**
- * Gets the price of one bitcoin (asks API for the price of 1 million USD then calculates the price of 1)
- * This is to ensure we don't incur loss (1M is 6 decimal places more precise than asking for the btc price of 1 dollar)
- * @returns price of 1 btc
- */
-export const getBTCPriceNow = async (): Promise<BigNumber> => {
-  const oneMillion = new BigNumber(1000000);
-  return getBTCFromUSDAtMarket(oneMillion).then((v) =>
-    oneMillion.dividedBy(v).dp(8)
-  );
-};
-
-/**
- * Fetches the price of 1 bitcoin at a particular date in history from the coindesk API
- * @param date
- * @returns price of 1 bitcoin as a BigNumber
- */
-export const getBTCPriceAtDate = async (
-  date: dayjs.Dayjs = dayjs()
-): Promise<BigNumber> => {
-  const formattedDate = date.format('YYYY-MM-DD');
-  const endpoint = `https://api.coindesk.com/v1/bpi/historical/close.json?start=${formattedDate}&end=${formattedDate}`;
-  return fetch(endpoint)
-    .then((data) => data.json())
-    .then((res) => new BigNumber(res.bpi[formattedDate]))
-    .catch((err) => {
-      console.error('Error getting bitcoin price', err);
-      return new BigNumber(0);
-    });
-};
-
-/**
- * Converts a usd amount to btc taking care of rounding errors.
- *
- * @param usdPrice usd to convert
- * @param btcPrice current price of 1 bitcoin
- * @returns usd to btc rounded to 8 decimal places.
- */
-export const convertUSDToBTC = (
-  usdPrice: BigNumber,
-  btcPrice: BigNumber
-): BigNumber =>
-  btcPrice.isEqualTo(0) ? new BigNumber(0) : usdPrice.dividedBy(btcPrice).dp(8);
-
+// helper for reducer
 const bnAdd = (n1: BigNumber, n2: BigNumber) => n1.plus(n2);
 
+// Given an array of expenses, it reduces it to an object with the 2 sums of btc and dollar prices
+// The btc price calculation depends on the current user settings
 export const addExpenseListPrices = (
   expenses: Expense[],
   calculationMode: CalculationModes,
@@ -83,9 +27,19 @@ export const addExpenseListPrices = (
     const usdPrice = expenses
       .map((expense) => expense.usdPrice)
       .reduce(bnAdd, new BigNumber(0));
-    return {usdPrice, btcPrice: convertUSDToBTC(usdPrice, currentPrice)};
+    return {usdPrice, btcPrice: convertCurrency(usdPrice, currentPrice)};
   }
 };
 
 export const classNames = (...classes: string[]): string =>
   classes.filter(Boolean).join(' ');
+
+export const isToday = (date: dayjs.Dayjs): boolean =>
+  dayjs().diff(date, 'day') === 0;
+
+export const convertCurrency = (
+  amount: BigNumber,
+  rate: BigNumber,
+  precision = 8
+): BigNumber =>
+  rate.isEqualTo(0) ? new BigNumber(0) : amount.dividedBy(rate).dp(precision);


### PR DESCRIPTION
The btc price and usd conversion methods were confusing, give the different user modes. They are now distilled to two api methods.

Logic:
1. If user saves or edits expense we **always** fetch the usd conversion for the amount at the date of the receipt and save it with the expense regardless of mode
2. For display purposes, we either use the saved amount (for purchase date mode) or we use the amount cached in the price manager (for market price mode).

The complexity that comes from deciding what prices to use and how to convert them based on what date you're using is all encapsulated in the api file.